### PR TITLE
COOP-270: Preparing for hex release

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,39 @@
+name: CD
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: '24'
+          elixir-version: '1.13'
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: setup hex
+        run: |
+          mix mix local.hex --force
+          mix local.rebar --force
+      - name: Get deps
+        run: mix deps.get
+      - name: Get version
+        run: |
+          VERSION=$(grep -m1 version mix.exs | cut -d'"' -f2)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Check version
+        if: github.ref_tag != ${{ env.VERSION }}
+        run: |
+          echo "Github ref tag [${{ github.ref_tag }}] is different from mix.exs version [${{ env.VERSION }}]"
+          exit 1
+      - name: Login to hex.pm
+        run: |
+          mix hex.config api_key "$HEX_AUTH_KEY"
+        env:
+          HEX_AUTH_KEY: ${{ secrets.HEX_AUTH_KEY }}
+      - name: Publish
+        run: mix hex.publish --yes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,8 @@ jobs:
       # Specify the OTP and Elixir versions to use when building
       # and running the workflow steps.
       matrix:
-        otp: ['25.0.4']       # Define the OTP version [required]
-        elixir: ['1.14.3']    # Define the elixir version [required]
+        otp: ['25.0.4']
+        elixir: ['1.14.3']
     steps:
       # Check out the code.
       - name: Checkout

--- a/.github/workflows/retire.yaml
+++ b/.github/workflows/retire.yaml
@@ -1,0 +1,44 @@
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: Retire reason
+        required: true
+        default: invalid
+        type: choice
+        options:
+          - renamed
+          - deprecated
+          - security
+          - invalid
+          - other
+      message:
+        description: Retire message
+        required: true
+        default: Version has a breaking bug
+        type: string
+      version:
+        description: Version to retire
+        required: true
+        default: x.y.z
+        type: string
+
+jobs:
+  retire:
+    runs-on: ubuntu-latest
+    env:
+      MESSAGE: ${{ inputs.message }}
+      REASON: ${{ inputs.reason }}
+      VERSION: ${{ inputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '24'
+          elixir-version: '1.13'
+      - run: echo "Attempting to retire version $VERSION"
+      - run: mix hex.config api_key "$HEX_AUTH_KEY"
+        env:
+          HEX_AUTH_KEY: ${{ secrets.HEX_AUTH_KEY }}
+      - run: mix hex.user whoami
+      - run: mix hex.retire cloudflare_access_ex "$VERSION" "$REASON" --message "$MESSAGE"

--- a/mix.exs
+++ b/mix.exs
@@ -1,11 +1,15 @@
 defmodule CloudflareAccessEx.MixProject do
   use Mix.Project
 
+  @source_url "https://github.com/primait/cloudflare_access_ex"
+  @version "0.1.0"
+
   def project do
     [
       app: :cloudflare_access_ex,
-      version: "0.1.0",
-      elixir: "~> 1.14",
+      description: "An elixir library to verify Cloudflare Access application tokens",
+      version: @version,
+      elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -16,7 +20,9 @@ defmodule CloudflareAccessEx.MixProject do
         doctor: :test,
         sobelow: :test,
         "deps.audit": :test
-      ]
+      ],
+      package: package(),
+      docs: docs(),
     ]
   end
 
@@ -48,4 +54,26 @@ defmodule CloudflareAccessEx.MixProject do
       {:test_server, "~> 0.1.13", only: :test}
     ]
   end
+
+  defp docs do
+    [
+      main: "CloudflareAccessEx",
+      extras: [
+        "LICENSE.md": [title: "License"]
+      ],
+      source_url: @source_url,
+      source_ref: @version,
+      formatters: ["html"]
+    ]
+  end
+
+  defp package do
+    [
+      name: "cloudflare_access_ex",
+      maintainers: ["Prima"],
+      licenses: ["MIT"],
+      links: %{"GitHub" => @source_url}
+    ]
+  end
+
 end


### PR DESCRIPTION
Adding CD & Retire workflows from template repo.

Setup metadata following example in prima_auth0_ex.

Lowered required Elixir version to 1.13 to match prima_auth0_ex.