### PR TITLE
Get principal from plug and improve ergonomics

### DIFF
--- a/lib/cloudflare_access_ex.ex
+++ b/lib/cloudflare_access_ex.ex
@@ -74,14 +74,14 @@ defmodule CloudflareAccessEx do
 
        or using `CloudflareAccessEx.ApplicationTokenVerifier` directly if you need even more control:
 
-           alias CloudflareAccessEx.ApplicationTokenVerifier
+           alias CloudflareAccessEx.{ApplicationTokenVerifier, Principal}
 
            verifier = ApplicationTokenVerifier.create(:my_cfa_app)
-           {:ok, token} = conn |> ApplicationTokenVerifier.verify(verifier)
+           {:ok, principal} = conn |> ApplicationTokenVerifier.verify(verifier)
 
-           case token do
-             :anonymous -> # do something
-             {:user, %{id: _, email: _}} -> # do something else
+           case principal do
+             %Principal{type: :anonymous} -> # do something
+             %Principal{type: :authenticated, user_id: _, email: _}} -> # do something else
            end
   """
 end

--- a/lib/cloudflare_access_ex.ex
+++ b/lib/cloudflare_access_ex.ex
@@ -72,12 +72,12 @@ defmodule CloudflareAccessEx do
 
            plug CloudflareAccessEx.Plug, cfa_app: :my_cfa_app
 
-       or using `CloudflareAccessEx.AccessTokenVerifier` directly if you need even more control:
+       or using `CloudflareAccessEx.ApplicationTokenVerifier` directly if you need even more control:
 
-           alias CloudflareAccessEx.AccessTokenVerifier
+           alias CloudflareAccessEx.ApplicationTokenVerifier
 
-           verifier = AccessTokenVerifier.create(:my_cfa_app)
-           {:ok, token} = conn |> AccessTokenVerifier.verify(verifier)
+           verifier = ApplicationTokenVerifier.create(:my_cfa_app)
+           {:ok, token} = conn |> ApplicationTokenVerifier.verify(verifier)
 
            case token do
              :anonymous -> # do something

--- a/lib/cloudflare_access_ex/plug.ex
+++ b/lib/cloudflare_access_ex/plug.ex
@@ -23,9 +23,9 @@ defmodule CloudflareAccessEx.Plug do
   and anonymous access is not allowed.
   """
   def call(conn, opts) do
-    verifier = CloudflareAccessEx.AccessTokenVerifier.create(opts[:cfa_app])
+    verifier = CloudflareAccessEx.ApplicationTokenVerifier.create(opts[:cfa_app])
 
-    case CloudflareAccessEx.AccessTokenVerifier.verify(conn, verifier) do
+    case CloudflareAccessEx.ApplicationTokenVerifier.verify(conn, verifier) do
       {:ok, :anonymous} ->
         if Keyword.get(opts, :allow_anonymous, false) do
           conn

--- a/lib/cloudflare_access_ex/plug.ex
+++ b/lib/cloudflare_access_ex/plug.ex
@@ -1,7 +1,7 @@
 defmodule CloudflareAccessEx.Plug do
   @moduledoc """
-  This plug is responsible for verifying the Cloudflare Access JWT token
-  and ensuring that it is valid.
+  This plug is responsible for blocking requets that do not have a valid
+  Cloudflare Access application token.
 
   ## Examples
 
@@ -14,35 +14,65 @@ defmodule CloudflareAccessEx.Plug do
   require Logger
   import Plug.ErrorHandler
 
+  alias CloudflareAccessEx.ApplicationTokenVerifier
+
+  @behaviour Plug
+
   @doc false
+  @impl Plug
   def init(opts), do: opts
 
   @doc """
-  This function is responsible for verifying the Cloudflare Access JWT token
-  It will reject the request if the token is invalid or if the token is anonymous
-  and anonymous access is not allowed.
+  Verifies the Cloudflare Access application token.
+
+  It will reject the request with 401 (Unauthorized) if the token is invalid
+  or if the token is anonymous and anonymous access is not allowed.
+
+  If the token is valid, the current user will be set in the conn's private map
+  and can be accessed via `CloudflareAccessEx.Plug.current_user/1`.
   """
+  @impl Plug
   def call(conn, opts) do
-    verifier = CloudflareAccessEx.ApplicationTokenVerifier.create(opts[:cfa_app])
+    verifier = ApplicationTokenVerifier.create(opts[:cfa_app])
 
-    case CloudflareAccessEx.ApplicationTokenVerifier.verify(conn, verifier) do
-      {:ok, :anonymous} ->
-        if Keyword.get(opts, :allow_anonymous, false) do
-          conn
-        else
-          unauthorized(conn)
-        end
-
-      {:ok, _} ->
-        conn
-
-      _else ->
-        unauthorized(conn)
+    case ApplicationTokenVerifier.verify(conn, verifier) do
+      {:ok, token} -> verified(conn, token, opts[:allow_anonymous] || false)
+      {:error, _} -> unauthorized(conn)
     end
+  end
+
+  @spec current_user(Plug.Conn.t()) :: ApplicationTokenVerifier.verified_token()
+  @doc """
+  Returns the current user. Will raise if executed on a request that has not passed through the plug
+  or if the plug has rejected the request.
+  """
+  def current_user(conn) do
+    conn.private[:cloudflare_access_ex_application_token] ||
+      raise "current_user/1 called on a request that has not passed successfully through CloudflareAccessEx.Plug"
+  end
+
+  defp verified(conn, token, allow_anonymous) do
+    case {token, allow_anonymous} do
+      {:anonymous, true} ->
+        authorized(conn, token)
+
+      {:anonymous, false} ->
+        Logger.warn("Anonymous access has been disabled in this application")
+        unauthorized(conn)
+
+      _ ->
+        authorized(conn, token)
+    end
+  end
+
+  defp authorized(conn, application_token) do
+    conn
+    |> Plug.Conn.put_private(:cloudflare_access_ex_application_token, application_token)
   end
 
   defp unauthorized(conn) do
     conn
+    |> Plug.Conn.put_private(:cloudflare_access_ex_application_token, nil)
     |> Plug.Conn.resp(401, "401 Unauthorized")
     |> Plug.Conn.halt()
   end

--- a/lib/cloudflare_access_ex/principal.ex
+++ b/lib/cloudflare_access_ex/principal.ex
@@ -1,0 +1,66 @@
+defmodule CloudflareAccessEx.Principal do
+  @moduledoc """
+  Defines the `Principal` struct for representing the principal identity of a user coming through Cloudflare Access.
+
+  A `Principal` can either represent an anonymous user or a user that has logged in through an identity provider (IdP).
+  The struct differentiates between these two states with the `:type` field, which can be `:anonymous` for users without
+  a user ID or email, or `:authenticated` for users who have been verified and have these attributes.
+  """
+  @enforce_keys [:type]
+  defstruct [:type, user_id: nil, email: nil]
+
+  @type anonymous_principal :: %__MODULE__{
+          type: :anonymous,
+          user_id: nil,
+          email: nil
+        }
+
+  @type authenticated_principal :: %__MODULE__{
+          type: :authenticated,
+          user_id: String.t(),
+          email: String.t()
+        }
+
+  @type t :: anonymous_principal() | authenticated_principal()
+
+  @doc """
+  Creates a `Principal` struct for an anonymous user.
+
+  ## Examples
+
+      iex> CloudflareAccessEx.Principal.anonymous()
+      %CloudflareAccessEx.Principal{type: :anonymous, user_id: nil, email: nil}
+  """
+  @spec anonymous() :: anonymous_principal()
+  def anonymous do
+    %__MODULE__{
+      type: :anonymous
+    }
+  end
+
+  @doc """
+  Creates a `Principal` struct for an authenticated user with the provided `user_id` and `email`.
+
+  ## Parameters
+
+  - `user_id`: The user ID from the IdP.
+  - `email`: The email address associated with the user.
+
+  ## Examples
+
+      iex> CloudflareAccessEx.Principal.authenticated("user123", "user@example.com")
+      %CloudflareAccessEx.Principal{
+        type: :authenticated,
+        user_id: "user123",
+        email: "user@example.com"
+      }
+  """
+  @spec authenticated(String.t(), String.t()) :: authenticated_principal()
+  def authenticated(user_id, email) do
+    %__MODULE__{
+      type: :authenticated,
+      user_id: user_id,
+      email: email
+    }
+  end
+end

--- a/test/cloudflare_access_ex/application_token_verifier_test.exs
+++ b/test/cloudflare_access_ex/application_token_verifier_test.exs
@@ -4,10 +4,10 @@ defmodule CloudflareAccessEx.ApplicationTokenVerifierTest do
   alias CloudflareAccessEx.JwksStrategy
 
   # Importing the test subject
-  alias CloudflareAccessEx.ApplicationTokenVerifier
+  alias CloudflareAccessEx.{ApplicationTokenVerifier, Principal}
   alias CloudflareAccessEx.Test.Simulator
 
-  doctest(CloudflareAccessEx.ApplicationTokenVerifier)
+  doctest(ApplicationTokenVerifier)
 
   setup %{} do
     :ok = Simulator.start_test_server()
@@ -82,7 +82,7 @@ defmodule CloudflareAccessEx.ApplicationTokenVerifierTest do
     token = Simulator.create_application_token(anonymous: true)
 
     assert ApplicationTokenVerifier.verify(token, verifier) ==
-             {:ok, :anonymous}
+             {:ok, Principal.anonymous()}
   end
 
   @tag start_simulator: true

--- a/test/cloudflare_access_ex/jwks_strategy_test.exs
+++ b/test/cloudflare_access_ex/jwks_strategy_test.exs
@@ -4,7 +4,6 @@ defmodule CloudflareAccessEx.JwksStrategyTest do
   alias CloudflareAccessEx.JwksStrategy
 
   # Importing the test subject
-  alias CloudflareAccessEx.ApplicationTokenVerifier
   alias CloudflareAccessEx.Test.Simulator
 
   # Yes, we're testing the GenServer callback. No we shouldn't really be doing this.
@@ -15,13 +14,13 @@ defmodule CloudflareAccessEx.JwksStrategyTest do
     # We set the retry time to 0ms and the poll time to 60 seconds, this means that the message we receive in the
     # assert_receive is for the retry, not for regular polling.
     {:ok, state, _} =
-      CloudflareAccessEx.JwksStrategy.init(
+      JwksStrategy.init(
         domain: Simulator.domain(),
         poll_retry_time_ms: 0,
         poll_time_ms: 60_000
       )
 
-    assert {:noreply, _} = CloudflareAccessEx.JwksStrategy.handle_continue(:update_signers, state)
+    assert {:noreply, _} = JwksStrategy.handle_continue(:update_signers, state)
 
     assert_receive :update_signers, 100
   end
@@ -31,13 +30,13 @@ defmodule CloudflareAccessEx.JwksStrategyTest do
 
     # See the previous comment for how/why this works.
     {:ok, state, _} =
-      CloudflareAccessEx.JwksStrategy.init(
+      JwksStrategy.init(
         domain: Simulator.domain(),
         poll_time_ms: 0,
         poll_retry_time_ms: 60_000
       )
 
-    assert {:noreply, _} = CloudflareAccessEx.JwksStrategy.handle_continue(:update_signers, state)
+    assert {:noreply, _} = JwksStrategy.handle_continue(:update_signers, state)
 
     assert_receive :update_signers, 100
   end

--- a/test/cloudflare_access_ex/jwks_strategy_test.exs
+++ b/test/cloudflare_access_ex/jwks_strategy_test.exs
@@ -4,7 +4,7 @@ defmodule CloudflareAccessEx.JwksStrategyTest do
   alias CloudflareAccessEx.JwksStrategy
 
   # Importing the test subject
-  alias CloudflareAccessEx.AccessTokenVerifier
+  alias CloudflareAccessEx.ApplicationTokenVerifier
   alias CloudflareAccessEx.Test.Simulator
 
   # Yes, we're testing the GenServer callback. No we shouldn't really be doing this.

--- a/test/cloudflare_access_ex/plug_test.exs
+++ b/test/cloudflare_access_ex/plug_test.exs
@@ -23,7 +23,7 @@ defmodule CloudflareAccessEx.PlugTest do
 
   @tag start_simulator: true
   test "extracts token from plug conn", %{cfa_app: cfa_app} do
-    token = Simulator.create_access_token()
+    token = Simulator.create_application_token()
 
     conn = %Plug.Conn{req_headers: [{"cf-access-jwt-assertion", token}]}
 
@@ -44,7 +44,7 @@ defmodule CloudflareAccessEx.PlugTest do
   describe "anonymous token" do
     @tag start_simulator: true
     test "is allowed when enabled", %{cfa_app: cfa_app} do
-      token = Simulator.create_access_token(anonymous: true)
+      token = Simulator.create_application_token(anonymous: true)
       conn = %Plug.Conn{req_headers: [{"cf-access-jwt-assertion", token}]}
 
       conn = CloudflareAccessExPlug.call(conn, cfa_app: cfa_app, allow_anonymous: true)
@@ -54,7 +54,7 @@ defmodule CloudflareAccessEx.PlugTest do
 
     @tag start_simulator: true
     test "is denied when disabled", %{cfa_app: cfa_app} do
-      token = Simulator.create_access_token(anonymous: true)
+      token = Simulator.create_application_token(anonymous: true)
       conn = %Plug.Conn{req_headers: [{"cf-access-jwt-assertion", token}]}
 
       conn = CloudflareAccessExPlug.call(conn, cfa_app: cfa_app, allow_anonymous: false)

--- a/test/cloudflare_access_ex/plug_test.exs
+++ b/test/cloudflare_access_ex/plug_test.exs
@@ -7,7 +7,70 @@ defmodule CloudflareAccessEx.PlugTest do
   alias CloudflareAccessEx.Plug, as: CloudflareAccessExPlug
   alias CloudflareAccessEx.Test.Simulator
 
-  setup %{} do
+  test "current_user/1 raises if plug not executed" do
+    conn = %Plug.Conn{}
+
+    assert_raise RuntimeError, fn ->
+      CloudflareAccessExPlug.current_user(conn)
+    end
+  end
+
+  describe "with simulator" do
+    setup [:start_simulator]
+
+    @tag start_simulator: true
+    test "extracts token from plug conn", %{cfa_app: cfa_app} do
+      token = Simulator.create_application_token()
+
+      conn = %Plug.Conn{req_headers: [{"cf-access-jwt-assertion", token}]}
+
+      conn = CloudflareAccessExPlug.call(conn, cfa_app: cfa_app)
+
+      assert CloudflareAccessExPlug.current_user(conn) == Simulator.user()
+      refute conn.halted
+    end
+
+    @tag start_simulator: true
+    test "errors if header missing from plug conn", %{cfa_app: cfa_app} do
+      conn = %Plug.Conn{req_headers: []}
+
+      conn = CloudflareAccessExPlug.call(conn, cfa_app: cfa_app)
+
+      assert conn.status == 401
+      assert conn.halted
+
+      assert_raise RuntimeError, fn ->
+        CloudflareAccessExPlug.current_user(conn)
+      end
+    end
+
+    @tag start_simulator: true
+    test "anonymous token is allowed when enabled", %{cfa_app: cfa_app} do
+      token = Simulator.create_application_token(anonymous: true)
+      conn = %Plug.Conn{req_headers: [{"cf-access-jwt-assertion", token}]}
+
+      conn = CloudflareAccessExPlug.call(conn, cfa_app: cfa_app, allow_anonymous: true)
+
+      assert CloudflareAccessExPlug.current_user(conn) == :anonymous
+      refute conn.halted
+    end
+
+    test "anonymous token is denied when disabled", %{cfa_app: cfa_app} do
+      token = Simulator.create_application_token(anonymous: true)
+      conn = %Plug.Conn{req_headers: [{"cf-access-jwt-assertion", token}]}
+
+      conn = CloudflareAccessExPlug.call(conn, cfa_app: cfa_app, allow_anonymous: false)
+
+      assert conn.halted
+      assert conn.status == 401
+
+      assert_raise RuntimeError, fn ->
+        CloudflareAccessExPlug.current_user(conn)
+      end
+    end
+  end
+
+  def start_simulator(_) do
     :ok = Simulator.start_test_server()
 
     {:ok, _} = start_supervised({JwksStrategy, [domain: Simulator.domain()]})
@@ -18,49 +81,6 @@ defmodule CloudflareAccessEx.PlugTest do
       audience: Simulator.audience()
     ]
 
-    {:ok, cfa_app: cfa_app}
-  end
-
-  @tag start_simulator: true
-  test "extracts token from plug conn", %{cfa_app: cfa_app} do
-    token = Simulator.create_application_token()
-
-    conn = %Plug.Conn{req_headers: [{"cf-access-jwt-assertion", token}]}
-
-    conn = CloudflareAccessExPlug.call(conn, cfa_app: cfa_app)
-
-    refute conn.halted
-  end
-
-  test "errors if header missing from plug conn", %{cfa_app: cfa_app} do
-    conn = %Plug.Conn{req_headers: []}
-
-    conn = CloudflareAccessExPlug.call(conn, cfa_app: cfa_app)
-
-    assert conn.status == 401
-    assert conn.halted
-  end
-
-  describe "anonymous token" do
-    @tag start_simulator: true
-    test "is allowed when enabled", %{cfa_app: cfa_app} do
-      token = Simulator.create_application_token(anonymous: true)
-      conn = %Plug.Conn{req_headers: [{"cf-access-jwt-assertion", token}]}
-
-      conn = CloudflareAccessExPlug.call(conn, cfa_app: cfa_app, allow_anonymous: true)
-
-      refute conn.halted
-    end
-
-    @tag start_simulator: true
-    test "is denied when disabled", %{cfa_app: cfa_app} do
-      token = Simulator.create_application_token(anonymous: true)
-      conn = %Plug.Conn{req_headers: [{"cf-access-jwt-assertion", token}]}
-
-      conn = CloudflareAccessExPlug.call(conn, cfa_app: cfa_app, allow_anonymous: false)
-
-      assert conn.halted
-      assert conn.status == 401
-    end
+    [cfa_app: cfa_app]
   end
 end

--- a/test/cloudflare_access_ex/principal_test.exs
+++ b/test/cloudflare_access_ex/principal_test.exs
@@ -1,0 +1,5 @@
+defmodule CloudflareAccessEx.PrincipalTest do
+  use ExUnit.Case, async: true
+
+  doctest(CloudflareAccessEx.Principal)
+end

--- a/test/support/simulator.ex
+++ b/test/support/simulator.ex
@@ -1,7 +1,7 @@
 defmodule CloudflareAccessEx.Test.Simulator do
   @moduledoc """
   Simulates cloudflare certs endpoint using test server and creates
-  access tokens that verify against those keys.
+  application tokens that verify against those keys.
   """
 
   alias CloudflareAccessEx.Test.Signers
@@ -11,7 +11,7 @@ defmodule CloudflareAccessEx.Test.Simulator do
   @default_audience "a8d3b7..."
   @default_kid "2b34ecb..."
 
-  def create_access_token(opts \\ []) do
+  def create_application_token(opts \\ []) do
     anonymous = Keyword.get(opts, :anonymous, false)
     sub = (anonymous && "") || Keyword.get(opts, :id, @default_user_id)
     email = Keyword.get(opts, :email, @default_user_email)

--- a/test/support/simulator.ex
+++ b/test/support/simulator.ex
@@ -46,11 +46,10 @@ defmodule CloudflareAccessEx.Test.Simulator do
   end
 
   def user(opts \\ []) do
-    {:user,
-     %{
-       id: Keyword.get(opts, :id, @default_user_id),
-       email: Keyword.get(opts, :email, @default_user_email)
-     }}
+    CloudflareAccessEx.Principal.authenticated(
+      Keyword.get(opts, :id, @default_user_id),
+      Keyword.get(opts, :email, @default_user_email)
+    )
   end
 
   def start_test_server() do


### PR DESCRIPTION
Ultimately wanted to use the user principal after the plug had been run (different paths for anon & authenticated users). Made some ergonomic & naming improvements along the way to get closer to a stable structure. See individual commit messages for more info.