### PR TITLE
fix: authorization rejection must be handled with 403 and not 401

### DIFF
--- a/lib/cloudflare_access_ex.ex
+++ b/lib/cloudflare_access_ex.ex
@@ -68,7 +68,7 @@ defmodule CloudflareAccessEx do
            config :cloudflare_access_ex, :my_other_cfa_app,
                domain: :example, audience: "7309b8..."
 
-    4. Verify tokens either using `CloudflareAccessEx.Plug` (this will return 401 for invalid tokens by default):
+    4. Verify tokens either using `CloudflareAccessEx.Plug` (this will return 403 for invalid tokens by default):
 
            plug CloudflareAccessEx.Plug, cfa_app: :my_cfa_app
 

--- a/lib/cloudflare_access_ex/plug.ex
+++ b/lib/cloudflare_access_ex/plug.ex
@@ -25,7 +25,7 @@ defmodule CloudflareAccessEx.Plug do
   @doc """
   Verifies the Cloudflare Access application token.
 
-  It will reject the request with 401 (Unauthorized) if the token is invalid
+  It will reject the request with 403 (Forbidden) if the token is invalid
   or if the token is anonymous and anonymous access is not allowed.
 
   If the token is valid, the principal will be set in the conn's private map
@@ -37,7 +37,7 @@ defmodule CloudflareAccessEx.Plug do
 
     case ApplicationTokenVerifier.verify(conn, verifier) do
       {:ok, token} -> verified(conn, token, opts[:allow_anonymous] || false)
-      {:error, _} -> unauthorized(conn)
+      {:error, _} -> forbidden(conn)
     end
   end
 
@@ -58,7 +58,7 @@ defmodule CloudflareAccessEx.Plug do
 
       {%Principal{type: :anonymous}, false} ->
         Logger.warn("Anonymous access has been disabled in this application")
-        unauthorized(conn)
+        forbidden(conn)
 
       _ ->
         authorized(conn, principal)
@@ -70,10 +70,10 @@ defmodule CloudflareAccessEx.Plug do
     |> Plug.Conn.put_private(:cloudflare_access_ex_principal, principal)
   end
 
-  defp unauthorized(conn) do
+  defp forbidden(conn) do
     conn
     |> Plug.Conn.put_private(:cloudflare_access_ex_principal, nil)
-    |> Plug.Conn.resp(401, "401 Unauthorized")
+    |> Plug.Conn.resp(403, "403 Forbidden")
     |> Plug.Conn.halt()
   end
 end

--- a/test/cloudflare_access_ex/plug_test.exs
+++ b/test/cloudflare_access_ex/plug_test.exs
@@ -33,7 +33,7 @@ defmodule CloudflareAccessEx.PlugTest do
 
       conn = CloudflareAccessEx.Plug.call(conn, cfa_app: cfa_app)
 
-      assert conn.status == 401
+      assert conn.status == 403
       assert conn.halted
 
       assert_raise RuntimeError, fn ->
@@ -59,7 +59,7 @@ defmodule CloudflareAccessEx.PlugTest do
       conn = CloudflareAccessEx.Plug.call(conn, cfa_app: cfa_app, allow_anonymous: false)
 
       assert conn.halted
-      assert conn.status == 401
+      assert conn.status == 403
 
       assert_raise RuntimeError, fn ->
         CloudflareAccessEx.Plug.get_principal(conn)


### PR DESCRIPTION
sadly the badly named status `401 unauthorized` actually means "no auth credential found - please provide one" rather than "access denied", which is instead 403.
note that for the purposes of this library absence of a credential is to consider a violation and thus rejected rather than sending a challenge via 401.