### PR TITLE
Relax plug version requirements

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule CloudflareAccessEx.MixProject do
       {:httpoison, "~> 1.7 or ~> 2.0"},
       {:joken, "~> 2.6"},
       {:joken_jwks, "~> 1.6.0"},
-      {:plug, "~> 1.14.2"},
+      {:plug, "~> 1.14"},
       {:test_server, "~> 0.1.13", only: :test}
     ]
   end


### PR DESCRIPTION
plug version was over specified (~> 1.14.2 == >= 1.14.2 & < 1.15). This caused issue on minor plug release to 1.15.x.

Now we only specify ~> 1.14 which means >= 1.14 & < 2.0